### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite+aiosqlite:///tmp/test.db
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest -q
+


### PR DESCRIPTION
## Summary
- add basic CI workflow to run tests with Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2dd818e8832fbb8dde75d2e5da37