### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite+aiosqlite:///tmp/test.db
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest -q
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ uvicorn[standard]>=0.25.0
 aiogram>=3.0.0
 asyncpg>=0.29.0  # PostgreSQL async driver
 aiosqlite>=0.19.0  # SQLite async driver for development
+pytest-asyncio>=0.23
+databases>=0.8

--- a/src/waitlist_service/database.py
+++ b/src/waitlist_service/database.py
@@ -1,4 +1,4 @@
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.ext.asyncio import create_async_engine
 import os
 from supabase import create_client, Client

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
+import pytest
 from src.waitlist_service.notifications import notifier
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+@pytest.mark.asyncio
 async def test_telegram():
     logger.info("Testing Telegram notifications")
     


### PR DESCRIPTION
## Summary
- add basic CI workflow to run tests with Python 3.11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2dd818e8832fbb8dde75d2e5da37